### PR TITLE
Fix typo error on validation

### DIFF
--- a/docs/0.11/Readme.md
+++ b/docs/0.11/Readme.md
@@ -588,7 +588,7 @@ Since `v0.10.13` you can do the `required` and `max:12` rule the following way:
 ```
 {
     "validation": {
-        "rules": [
+        "rule": [
             "required",
             "max:12"
         ]


### PR DESCRIPTION
There's an error on validation, it should use `rule` instead of `rules`.